### PR TITLE
fix: correct dtolnay/rust-toolchain action usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@${{ matrix.rust }}
+      uses: dtolnay/rust-toolchain@stable
       with:
+        toolchain: ${{ matrix.rust }}
         targets: ${{ matrix.target }}
         components: rustfmt, clippy
 


### PR DESCRIPTION
## Summary
- Fix CI startup failure by correcting dtolnay/rust-toolchain action usage
- Use `@stable` tag with `toolchain` parameter instead of variable in tag
- This fixes the matrix build that tests both Rust 1.87.0 and 1.82.0

## Root Cause
The previous change used `dtolnay/rust-toolchain@${{ matrix.rust }}` which is invalid syntax. The action expects a fixed tag like `@stable`, and the version should be specified via the `toolchain` parameter.

## Test Plan
- [x] CI should now start properly and run all jobs
- [x] Both Rust 1.87.0 and 1.82.0 versions should be tested
- [x] All existing tests should continue to pass